### PR TITLE
quave:slingshot - Add cloudflare R2 compatibility

### DIFF
--- a/meteor-slingshot/lib/upload.js
+++ b/meteor-slingshot/lib/upload.js
@@ -202,13 +202,22 @@ Slingshot.Upload = function (directive, metaData) {
         );
       });
 
-      xhr.open('POST', self.instructions.upload, true);
+      let isR2 = self.instructions.upload.includes('r2.cloudflarestorage.com');
+      let method = 'POST';
+      let formData = buildFormData();
+
+      if (isR2) {
+        method = 'PUT';
+        formData = self.file;
+      }
+
+      xhr.open(method, self.instructions.upload, true);
 
       _.each(self.instructions.headers, function (value, key) {
         xhr.setRequestHeader(key, value);
       });
 
-      xhr.send(buildFormData());
+      xhr.send(formData);
       self.xhr = xhr;
 
       return self;

--- a/meteor-slingshot/package.js
+++ b/meteor-slingshot/package.js
@@ -19,6 +19,7 @@ Package.onUse(function (api) {
     [
       'lib/directive.js',
       'lib/storage-policy.js',
+      'services/cloudflare-r2.js',
       'services/aws-s3.js',
       'services/google-cloud.js',
       'services/rackspace.js',

--- a/meteor-slingshot/services/cloudflare-r2.js
+++ b/meteor-slingshot/services/cloudflare-r2.js
@@ -1,0 +1,182 @@
+const crypto = Npm.require('crypto');
+const url = Npm.require('url');
+
+Slingshot.CloudflareR2 = {
+  accessId: 'AccessKeyId',
+  secretKey: 'SecretAccessKey',
+
+  directiveMatch: {
+    bucket: String,
+    accountId: String,
+    endpoint: String,
+    cdn: Match.Optional(String),
+    region: Match.Optional(String),
+    AccessKeyId: String,
+    SecretAccessKey: String,
+    acl: Match.Optional(String),
+    key: Match.OneOf(String, Function),
+    expire: Match.Where(function (expire) {
+      check(expire, Number);
+      return expire > 0;
+    }),
+  },
+
+  directiveDefault: {
+    region: 'auto',
+    expire: 60 * 60,
+  },
+
+  getContentDisposition: async function (method, directive, file, meta) {
+    var getContentDisposition = directive.contentDisposition;
+
+    if (!_.isFunction(getContentDisposition)) {
+      getContentDisposition = function () {
+        var filename = file.name && encodeURIComponent(file.name);
+
+        return (
+          directive.contentDisposition ||
+          (filename &&
+            'inline; filename="' +
+              filename +
+              "\"; filename*=utf-8''" +
+              filename)
+        );
+      };
+    }
+
+    return getContentDisposition.call(method, file, meta);
+  },
+
+  upload: async function (method, directive, file, meta) {
+    try {
+      const policy = new Slingshot.StoragePolicy()
+        .expireIn(directive.expire)
+        .contentLength(0, Math.min(file.size, directive.maxSize || Infinity));
+
+      let key;
+      if (_.isFunction(directive.key)) {
+        key = await Promise.resolve(directive.key.call(method, file, meta));
+      } else {
+        key = directive.key;
+      }
+
+      const signedUrl = await this.getSignedUrl(directive, key, file.type);
+
+      const downloadUrl = directive.cdn
+        ? `${directive.cdn}/${key}`
+        : `${directive.endpoint}/${directive.bucket}/${key}`;
+
+      return {
+        upload: signedUrl,
+        download: downloadUrl,
+        postData: [],
+      };
+    } catch (error) {
+      console.error('Error in CloudflareR2 upload:', error);
+      throw error;
+    }
+  },
+
+  getSignedUrl: async function (directive, key, contentType) {
+    try {
+      const date = new Date();
+      const dateString = date.toISOString().replace(/[:-]|\.\d{3}/g, '');
+      const datestamp = dateString.slice(0, 8);
+      const credential = `${directive[this.accessId]}/${datestamp}/${
+        directive.region
+      }/s3/aws4_request`;
+
+      const queryParams = new url.URLSearchParams({
+        'X-Amz-Algorithm': 'AWS4-HMAC-SHA256',
+        'X-Amz-Credential': credential,
+        'X-Amz-Date': dateString,
+        'X-Amz-Expires': directive.expire.toString(),
+        'X-Amz-SignedHeaders': 'host',
+      });
+
+      const canonicalRequest = this.getCanonicalRequest(
+        directive,
+        key,
+        queryParams
+      );
+      const stringToSign = this.getStringToSign(
+        dateString,
+        datestamp,
+        directive.region,
+        canonicalRequest
+      );
+      const signature = this.getSignature(
+        directive[this.secretKey],
+        datestamp,
+        directive.region,
+        stringToSign
+      );
+
+      queryParams.set('X-Amz-Signature', signature);
+
+      return `${directive.endpoint}/${
+        directive.bucket
+      }/${key}?${queryParams.toString()}`;
+    } catch (error) {
+      console.error('Error in getSignedUrl:', error);
+      throw error;
+    }
+  },
+
+  getCanonicalRequest: function (directive, key, queryParams) {
+    const canonicalUri = `/${directive.bucket}/${key}`;
+    const canonicalQueryString = queryParams.toString();
+    const canonicalHeaders = `host:${new url.URL(directive.endpoint).host}\n`;
+    const signedHeaders = 'host';
+    const payloadHash = 'UNSIGNED-PAYLOAD';
+
+    return [
+      'PUT',
+      canonicalUri,
+      canonicalQueryString,
+      canonicalHeaders,
+      signedHeaders,
+      payloadHash,
+    ].join('\n');
+  },
+
+  getStringToSign: function (dateString, datestamp, region, canonicalRequest) {
+    const hash = crypto
+      .createHash('sha256')
+      .update(canonicalRequest)
+      .digest('hex');
+    return [
+      'AWS4-HMAC-SHA256',
+      dateString,
+      `${datestamp}/${region}/s3/aws4_request`,
+      hash,
+    ].join('\n');
+  },
+
+  getSignature: function (secretKey, datestamp, region, stringToSign) {
+    const getSignatureKey = (key, dateStamp, regionName) => {
+      const kDate = crypto
+        .createHmac('sha256', `AWS4${key}`)
+        .update(dateStamp)
+        .digest();
+      const kRegion = crypto
+        .createHmac('sha256', kDate)
+        .update(regionName)
+        .digest();
+      const kService = crypto
+        .createHmac('sha256', kRegion)
+        .update('s3')
+        .digest();
+      return crypto
+        .createHmac('sha256', kService)
+        .update('aws4_request')
+        .digest();
+    };
+
+    const signingKey = getSignatureKey(secretKey, datestamp, region);
+    return crypto
+      .createHmac('sha256', signingKey)
+      .update(stringToSign)
+      .digest('hex');
+  },
+};


### PR DESCRIPTION
# Changelog:
- Added cloudlflare-r2 to services, signing requests and preparing endpoint using S3 compatible api
- Added condition to upload.js to manage correctly when to use POST or PUT requests (Cloudflare R2 doesn't support POST requests)


Todo: 

- [ ] Add documentation to readme.md
- [ ] Bump up package version
- [ ] Add example to [Quave template](https://github.com/quavedev/meteor-packages/issues/github.com/quavedev/meteor-template)