### PR TITLE
Handle blocked cron jobs

### DIFF
--- a/synced-cron/CHANGELOG.md
+++ b/synced-cron/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 
-## 2.2.1 (2024-11-19)
+## 2.2.1 (2024-12-13)
 
 - Add automatic cleanup of running jobs when the process encounters a fatal error (uncaught exceptions and unhandled rejections). The cleanup consists of marking the job as finished and adding a `terminatedBy` field to the job history collection to indicate how the job was terminated.
   - Add tests for the new functionality.

--- a/synced-cron/CHANGELOG.md
+++ b/synced-cron/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+
+## 2.2.1 (2024-11-19)
+
+- Add automatic cleanup of running jobs when the process encounters a fatal error (uncaught exceptions and unhandled rejections). The cleanup consists of marking the job as finished and adding a `terminatedBy` field to the job history collection to indicate how the job was terminated.
+  - Add tests for the new functionality.
+
 ## 2.2.0 (2024-10-07)
 
 BREAKING CHANGE: `allowParallelExecution` is now `false` by default. Before, this package was allowing parallel executions except when the intendedAt was equal. Now, it's not allowing by default any parallel execution. So, if you want to keep the old behavior, in your add function, you should always provide `allowParallelExecution` as true. 

--- a/synced-cron/package.js
+++ b/synced-cron/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   summary:
     'Allows you to define and run scheduled jobs across multiple servers.',
-  version: '2.2.0',
+  version: '2.2.1',
   name: 'quave:synced-cron',
   git: 'https://github.com/quavedev/meteor-synced-cron.git',
 });

--- a/synced-cron/package.js
+++ b/synced-cron/package.js
@@ -13,7 +13,7 @@ Package.onUse(function (api) {
 
   api.use('ecmascript');
 
-  api.use(['check', 'mongo', 'logging'], 'server');
+  api.use(['check', 'mongo', 'logging', 'random'], 'server');
 
   api.addFiles(['synced-cron-server.js'], 'server');
 
@@ -21,7 +21,7 @@ Package.onUse(function (api) {
 });
 
 Package.onTest(function (api) {
-  api.use(['check', 'mongo'], 'server');
+  api.use(['check', 'mongo', 'random'], 'server');
   api.use(['tinytest', 'logging']);
 
   api.addFiles(['synced-cron-server.js', 'synced-cron-tests.js'], ['server']);

--- a/synced-cron/synced-cron-server.js
+++ b/synced-cron/synced-cron-server.js
@@ -2,7 +2,7 @@
 SyncedCron = {
   _entries: {},
   running: false,
-  processId: `cron-${Date.now()}`,
+  processId: Random.id(),
   options: {
     //Log job run details to console
     log: true,

--- a/synced-cron/synced-cron-tests.js
+++ b/synced-cron/synced-cron-tests.js
@@ -263,7 +263,7 @@ Tinytest.addAsync(
   'allowParallelExecution: true allows parallel execution',
   async function (test) {
     await SyncedCron._reset();
-    
+
     const testEntry = Object.assign({}, TestEntry, {
       name: 'Parallel Job',
       allowParallelExecution: true,
@@ -291,7 +291,7 @@ Tinytest.addAsync(
     // Check that both jobs ran
     const jobHistories = await SyncedCron._collection.find().fetchAsync();
     test.equal(jobHistories.length, 2, 'Both jobs should have run');
-    
+
     if (jobHistories.length >= 2) {
       test.equal(jobHistories[0].result, 'ran', 'First job should have run');
       test.equal(jobHistories[1].result, 'ran', 'Second job should have run');
@@ -308,7 +308,7 @@ Tinytest.addAsync(
   'allowParallelExecution: false prevents parallel execution',
   async function (test) {
     await SyncedCron._reset();
-    
+
     const testEntry = Object.assign({}, TestEntry, {
       name: 'Non-Parallel Job',
       allowParallelExecution: false,
@@ -336,7 +336,7 @@ Tinytest.addAsync(
     // Check that only one job ran
     const jobHistories = await SyncedCron._collection.find().fetchAsync();
     test.equal(jobHistories.length, 1, 'Only one job should have run');
-    
+
     if (jobHistories.length > 0) {
       test.equal(jobHistories[0].result, 'ran', 'The job should have run');
     }
@@ -347,7 +347,7 @@ Tinytest.addAsync(
   'timeoutToConsiderRunningForParallelExecution allows execution after timeout',
   async function (test) {
     await SyncedCron._reset();
-    
+
     const testEntry = Object.assign({}, TestEntry, {
       name: 'Timeout Job',
       allowParallelExecution: false,
@@ -376,7 +376,7 @@ Tinytest.addAsync(
     // Check that both jobs ran
     const jobHistories = await SyncedCron._collection.find().fetchAsync();
     test.equal(jobHistories.length, 2, 'Both jobs should have run');
-    
+
     if (jobHistories.length >= 2) {
       test.equal(jobHistories[0].result, 'ran', 'First job should have run');
       test.equal(jobHistories[1].result, 'ran', 'Second job should have run');
@@ -389,7 +389,7 @@ Tinytest.addAsync(
   'onSuccess callback is called with correct arguments',
   async function (test) {
     await SyncedCron._reset();
-    
+
     let onSuccessCalled = false;
     const testEntry = {
       name: 'Success Job',
@@ -420,7 +420,7 @@ Tinytest.addAsync(
   'onError callback is called with correct arguments',
   async function (test) {
     await SyncedCron._reset();
-    
+
     let onErrorCalled = false;
     const testEntry = {
       name: 'Error Job',
@@ -445,5 +445,138 @@ Tinytest.addAsync(
     await SyncedCron._entryWrapper(entry)(new Date());
 
     test.isTrue(onErrorCalled, 'onError should have been called');
+  }
+);
+
+Tinytest.addAsync(
+  'Cleanup marks jobs as terminated on SIGTERM',
+  async function (test) {
+    await SyncedCron._reset();
+
+    // Create a long-running job
+    const testEntry = {
+      name: 'Long Running Job',
+      schedule: function (parser) {
+        return parser.text('every 1 second');
+      },
+      job: async function () {
+        await new Promise(resolve => setTimeout(resolve, 5000));
+        return 'completed';
+      }
+    };
+
+    SyncedCron.add(testEntry);
+    const entry = SyncedCron._entries[testEntry.name];
+
+    // Start the job but don't await it
+    SyncedCron._entryWrapper(entry)(new Date());
+
+    // Wait a bit to ensure the job has started
+    await new Promise(resolve => setTimeout(resolve, 100));
+
+    // Simulate SIGTERM
+    process.emit('SIGTERM');
+
+    // Wait for cleanup to complete
+    await new Promise(resolve => setTimeout(resolve, 100));
+
+    // Check the job history
+    const jobHistory = await SyncedCron._collection.findOneAsync();
+
+    test.isNotNull(jobHistory, 'Job history should exist');
+    test.isNotUndefined(jobHistory.finishedAt, 'Job should be marked as finished');
+    test.equal(jobHistory.terminatedBy, 'SIGTERM', 'Job should be marked as terminated by SIGTERM');
+  }
+);
+
+Tinytest.addAsync(
+  'Cleanup marks jobs as terminated on uncaught exception',
+  async function (test) {
+    await SyncedCron._reset();
+
+    // Create a long-running job
+    const testEntry = {
+      name: 'Exception Job',
+      schedule: function (parser) {
+        return parser.text('every 1 second');
+      },
+      job: async function () {
+        await new Promise(resolve => setTimeout(resolve, 5000));
+        return 'completed';
+      }
+    };
+
+    SyncedCron.add(testEntry);
+    const entry = SyncedCron._entries[testEntry.name];
+
+    // Start the job but don't await it
+    SyncedCron._entryWrapper(entry)(new Date());
+
+    // Wait a bit to ensure the job has started
+    await new Promise(resolve => setTimeout(resolve, 100));
+
+    // Create a fatal error
+    const fatalError = new Error('Fatal error')
+
+    // Simulate fatal error
+    process.emit('uncaughtException', fatalError);
+
+    // Wait for cleanup to complete
+    await new Promise(resolve => setTimeout(resolve, 100));
+
+    // Check the job history
+    const jobHistory = await SyncedCron._collection.findOneAsync();
+
+    test.isNotNull(jobHistory, 'Job history should exist');
+    test.isNotUndefined(jobHistory.finishedAt, 'Job should be marked as finished');
+    test.equal(jobHistory.terminatedBy, 'UNCAUGHT_EXCEPTION', 'Job should be marked as terminated by UNCAUGHT_EXCEPTION');
+  }
+);
+
+Tinytest.addAsync(
+  'Non-fatal errors do not trigger cleanup',
+  async function (test) {
+    await SyncedCron._reset();
+
+    // Create a long-running job
+    const testEntry = {
+      name: 'Non-Fatal Error Job',
+      schedule: function (parser) {
+        return parser.text('every 1 second');
+      },
+      job: async function () {
+        await new Promise(resolve => setTimeout(resolve, 5000));
+        return 'completed';
+      }
+    };
+
+    SyncedCron.add(testEntry);
+    const entry = SyncedCron._entries[testEntry.name];
+
+    // Start the job but don't await it
+    SyncedCron._entryWrapper(entry)(new Date());
+
+    // Wait a bit to ensure the job has started
+    await new Promise(resolve => setTimeout(resolve, 100));
+
+    // Add another error handler to make the error non-fatal
+    const errorHandler = () => { };
+    process.on('uncaughtException', errorHandler);
+
+    // Simulate non-fatal error
+    process.emit('uncaughtException', new Error('Non-fatal error'));
+
+    // Wait a bit
+    await new Promise(resolve => setTimeout(resolve, 100));
+
+    // Check the job history
+    const jobHistory = await SyncedCron._collection.findOneAsync();
+
+    test.isNotNull(jobHistory, 'Job history should exist');
+    test.equal(jobHistory.finishedAt, undefined, 'Job should not be marked as finished');
+    test.equal(jobHistory.terminatedBy, undefined, 'Job should not be marked as terminated');
+
+    // Cleanup
+    process.removeListener('uncaughtException', errorHandler);
   }
 );


### PR DESCRIPTION
## 2.2.1 (2024-11-19)

- Add automatic cleanup of running jobs when the process encounters a fatal error (uncaught exceptions and unhandled rejections). The cleanup consists of marking the job as finished and adding a `terminatedBy` field to the job history collection to indicate how the job was terminated.
  - Add tests for the new functionality.