### PR TITLE
Enhance collections with customizable persistable and softRemoval composers

### DIFF
--- a/collections/CHANGELOG.md
+++ b/collections/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## CHANGELOG
 
+### 3.1.1 (2024-12-09)
+Enhance persistable and softRemoval composers with `shouldFetchFullDoc` option
+
+- Updated the persistable composer to include a `shouldFetchFullDoc` parameter, allowing for the retrieval of the full existing document during operations.
+- Modified the softRemoval composer to also accept the `shouldFetchFullDoc` option, improving document handling before removal.
+- Adjusted related method signatures and documentation to reflect these changes, enhancing clarity and maintainability.
+
 ### 3.1.0 (2024-12-06)
 
 - Adds `shouldFetchFullDoc` flag to `softRemoval` and `persistable` composers.

--- a/collections/CHANGELOG.md
+++ b/collections/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## CHANGELOG
 
+### 3.1.0 (2024-12-06)
+
+- Adds `shouldFetchFullDoc` flag to `softRemoval` and `persistable` composers.
+- Adds `afterInsert` and `afterUpdate` to `persistable` composer.
+- Adds `afterRemove` to `softRemoval` composer.
+- Now `softRemoval` composer should be called as a function when adding on the composers array.
+
 ### 3.0.4 (2024-10-13)
 
 - Adds types using only zodern:types.

--- a/collections/README.md
+++ b/collections/README.md
@@ -134,7 +134,7 @@ const savedUser = await UsersCollection.save(
 );
 ```
 
-You can also customize the `persistable` composer by providing `beforeInsert` and `beforeUpdate` functions:
+You can customize the `persistable` composer by providing `beforeInsert` and `beforeUpdate` functions:
 
 ```js
 const customPersistable = persistable({
@@ -154,6 +154,33 @@ export const CustomUsersCollection = createCollection({
 });
 ```
 
+You can also customize the `persistable` composer by providing the `afterInsert` and `afterUpdate` functions, which apply an action after the document has been inserted or updated.
+
+```js
+const customPersistable = persistable({
+  afterInsert: ({ doc }) => {
+    // Any action after the document has been inserted
+  },
+  afterUpdate: ({ doc }) => {
+    // Any action after the document has been updated
+  },
+});
+
+export const CustomUsersCollection = createCollection({
+  name: 'customUsers',
+  composers: [customPersistable],
+});
+```
+
+Also, you can use the `shouldFetchFullDoc` flag to decide whether the old document should be fetched from the database and used in the `afterUpdate` function.
+
+```js
+const savedUser = await UsersCollection.save(
+  { _id: user._id, name: 'Bob' },
+  { shouldFetchFullDoc: true }
+);
+```
+
 The `persistable` composer provides a convenient way to handle document persistence with automatic timestamp management and customizable pre-save hooks.
 
 ##### softRemoval
@@ -167,7 +194,7 @@ import { createCollection, softRemoval } from 'meteor/quave:collections';
 
 export const UsersCollection = createCollection({
   name: 'users',
-  composers: [softRemoval],
+  composers: [softRemoval()],
 });
 
 // Example of soft removal
@@ -184,6 +211,20 @@ console.log(removedUser); // { _id: ..., name: 'John Doe', isRemoved: true }
 // The user seems to be removed
 const removedUser2 = await UsersCollection.findOneAsync({ _id: user._id });
 console.log(removedUser2); // null
+```
+
+You can also customize the `softRemoval` composer by providing the `afterRemove` function. This function will be called after the document has been removed, and you can provide the documents to this function by adding the flag `shouldFetchFullDoc`.
+
+```js
+const customSoftRemoval = softRemoval({
+  afterRemove: ({ doc }) => {
+    // Any action after the document has been removed
+  },
+});
+```
+
+```js
+await UsersCollection.removeAsync(user._id, { shouldFetchFullDoc: true });
 ```
 
 #### Create your own composer

--- a/collections/README.md
+++ b/collections/README.md
@@ -213,12 +213,12 @@ const removedUser2 = await UsersCollection.findOneAsync({ _id: user._id });
 console.log(removedUser2); // null
 ```
 
-You can also customize the `softRemoval` composer by providing the `afterRemove` function. This function will be called after the document has been removed, and you can provide the documents to this function by adding the flag `shouldFetchFullDoc`.
+You can also customize the `softRemoval` composer by providing the `afterRemove` function. This function will be called after the documents has been removed, and you can provide the documents to this function by adding the flag `shouldFetchFullDoc`.
 
 ```js
 const customSoftRemoval = softRemoval({
-  afterRemove: ({ doc }) => {
-    // Any action after the document has been removed
+  afterRemove: ({ docs }) => {
+    // Any action after the documents have been removed
   },
 });
 ```

--- a/collections/composers/persistable.js
+++ b/collections/composers/persistable.js
@@ -53,8 +53,10 @@ export const persistable =
         doc,
         { selectorToFindId, projection, skipReturn, shouldFetchFullDoc } = {}
       ) {
+        const self = this;
+
         const oldDoc = await getIdOrDocOrNullAsync({
-          collection: this,
+          collection: self,
           doc,
           selectorToFindId,
           shouldFetchFullDoc,
@@ -62,15 +64,15 @@ export const persistable =
         if (oldDoc) {
           const { ...data } = doc;
           const dataToSave = { ...data, updatedAt: new Date() };
-          await this.updateAsync(oldDoc._id, {
+          await self.updateAsync(oldDoc._id, {
             $set: await beforeUpdate({
-              collection: this,
+              collection: self,
               doc: dataToSave,
               isUpdate: true,
             }),
           });
           await afterUpdate({
-            collection: this,
+            collection: self,
             oldDoc,
             doc: dataToSave,
             isUpdate: true,
@@ -79,7 +81,7 @@ export const persistable =
           if (skipReturn) {
             return null;
           }
-          return this.findOneAsync(oldDoc._id, {
+          return self.findOneAsync(oldDoc._id, {
             ...(projection && { projection }),
           });
         }
@@ -91,20 +93,20 @@ export const persistable =
         };
         const insertedId = await this.insertAsync(
           await beforeInsert({
-            collection: this,
+            collection: self,
             doc: dataToInsert,
             isInsert: true,
           })
         );
         await afterInsert({
-          collection: this,
+          collection: self,
           doc: dataToInsert,
           isInsert: true,
         });
         if (skipReturn) {
           return null;
         }
-        return this.findOneAsync(insertedId, {
+        return self.findOneAsync(insertedId, {
           ...(projection && { projection }),
         });
       },

--- a/collections/composers/persistable.js
+++ b/collections/composers/persistable.js
@@ -54,12 +54,12 @@ export const persistable =
         { selectorToFindId, projection, skipReturn, shouldFetchFullDoc } = {}
       ) {
         const oldDoc = await getIdOrDocOrNullAsync({
-          collection,
+          collection: this,
           doc,
           selectorToFindId,
           shouldFetchFullDoc,
         });
-        if (oldDoc?._id) {
+        if (oldDoc) {
           const { ...data } = doc;
           const dataToSave = { ...data, updatedAt: new Date() };
           await this.updateAsync(oldDoc._id, {

--- a/collections/composers/persistable.js
+++ b/collections/composers/persistable.js
@@ -2,7 +2,7 @@ const getIdOrDocOrNullAsync = async ({
   collection,
   doc,
   selectorToFindId,
-  shouldFetchFullDoc = false,
+  shouldFetchFullDoc,
 }) => {
   if (doc._id) {
     return shouldFetchFullDoc
@@ -22,6 +22,7 @@ const getIdOrDocOrNullAsync = async ({
  * Creates a persistable composer for a collection.
  *
  * @param {Object} options - The options for the persistable composer.
+ * @param {boolean} [options.shouldFetchFullDoc] - If true, fetches the full existing document.
  * @param {Function} [options.beforeInsert=({doc}) => doc] - A function to modify the document before insertion.
  * @param {Function} [options.beforeUpdate=({doc}) => doc] - A function to modify the document before update.
  * @param {Function} [options.afterInsert=({doc}) => doc] - A function to do any additional actions after insertion.
@@ -30,6 +31,7 @@ const getIdOrDocOrNullAsync = async ({
  */
 export const persistable =
   ({
+     shouldFetchFullDoc = false,
     beforeInsert = ({ doc }) => doc,
     beforeUpdate = ({ doc }) => doc,
     afterInsert = ({ doc }) => doc,
@@ -46,12 +48,11 @@ export const persistable =
        * @param {Object} [options.selectorToFindId] - A selector to find an existing document's ID.
        * @param {Object} [options.projection] - The projection to use when returning the saved document.
        * @param {boolean} [options.skipReturn] - If true, doesn't return the saved document.
-       * @param {boolean} [options.shouldFetchFullDoc] - If true, fetches the full existing document.
        * @returns {Promise<Object|null>} The saved document, or null if skipReturn is true.
        */
       async save(
         doc,
-        { selectorToFindId, projection, skipReturn, shouldFetchFullDoc } = {}
+        { selectorToFindId, projection, skipReturn } = {}
       ) {
         const self = this;
 

--- a/collections/composers/softRemoval.js
+++ b/collections/composers/softRemoval.js
@@ -19,7 +19,7 @@ const filterOptions = (options = {}) => {
  * @returns {Object} An enhanced collection with soft removal methods.
  */
 export const softRemoval =
-  ({ afterRemove = ({ doc }) => doc } = {}) =>
+  ({ afterRemove = ({ docs }) => docs } = {}) =>
   (collection) => {
     const originalFind = collection.find.bind(collection);
     const originalFindOneAsync = collection.findOneAsync.bind(collection);
@@ -55,7 +55,12 @@ export const softRemoval =
 
         if (hardRemove) {
           await originalRemoveAsync(selector);
-          return afterRemove({ doc: docsToRemove, collection, isRemove: true });
+          return afterRemove({
+            docs: docsToRemove,
+            collection,
+            isRemove: true,
+            isHardRemove: true,
+          });
         }
 
         await originalUpdateAsync(
@@ -72,7 +77,12 @@ export const softRemoval =
           { multi: true }
         );
 
-        return afterRemove({ doc: docsToRemove, collection, isRemove: true });
+        return afterRemove({
+          docs: docsToRemove,
+          collection,
+          isRemove: true,
+          isHardRemove: false,
+        });
       },
     });
   };

--- a/collections/composers/softRemoval.js
+++ b/collections/composers/softRemoval.js
@@ -19,7 +19,7 @@ const filterOptions = (options = {}) => {
  * @returns {Object} An enhanced collection with soft removal methods.
  */
 export const softRemoval =
-  ({ afterRemove = ({ docs }) => docs } = {}) =>
+  ({ shouldFetchFullDoc = false, afterRemove = ({ docs }) => docs } = {}) =>
   (collection) => {
     const originalFind = collection.find.bind(collection);
     const originalFindOneAsync = collection.findOneAsync.bind(collection);
@@ -47,7 +47,7 @@ export const softRemoval =
       },
       async removeAsync(
         selector,
-        { shouldFetchFullDoc, hardRemove, ...options } = {}
+        { hardRemove, ...options } = {}
       ) {
         const docsToRemove =
           shouldFetchFullDoc &&

--- a/collections/composers/softRemoval.js
+++ b/collections/composers/softRemoval.js
@@ -64,9 +64,7 @@ export const softRemoval =
         }
 
         await originalUpdateAsync(
-          {
-            ...toSelector(selector),
-          },
+          toSelector(selector),
           {
             $set: {
               ...(options.$set || {}),

--- a/collections/composers/softRemoval.js
+++ b/collections/composers/softRemoval.js
@@ -18,48 +18,61 @@ const filterOptions = (options = {}) => {
  * @param {Mongo.Collection} collection - The collection to enhance with soft removal functionality.
  * @returns {Object} An enhanced collection with soft removal methods.
  */
-export const softRemoval = (collection) => {
-  const originalFind = collection.find.bind(collection);
-  const originalFindOneAsync = collection.findOneAsync.bind(collection);
-  const originalUpdateAsync = collection.updateAsync.bind(collection);
-  const originalRemoveAsync = collection.removeAsync.bind(collection);
-  // eslint-disable-next-line prefer-object-spread
-  return Object.assign({}, collection, {
-    find(selector, options) {
-      return originalFind(
-        {
-          ...toSelector(selector),
-          ...filterOptions(options),
-        },
-        options
-      );
-    },
-    async findOneAsync(selector, options) {
-      return originalFindOneAsync(
-        {
-          ...toSelector(selector),
-          ...filterOptions(options),
-        },
-        options
-      );
-    },
-    async removeAsync(selector, options = {}) {
-      if (options.hardRemove) {
-        return originalRemoveAsync(selector);
-      }
-      return originalUpdateAsync(
-        {
-          ...toSelector(selector),
-        },
-        {
-          $set: {
-            ...(options.$set || {}),
-            isRemoved: true,
-            removedAt: new Date(),
+export const softRemoval =
+  ({ afterRemove = ({ doc }) => doc } = {}) =>
+  (collection) => {
+    const originalFind = collection.find.bind(collection);
+    const originalFindOneAsync = collection.findOneAsync.bind(collection);
+    const originalUpdateAsync = collection.updateAsync.bind(collection);
+    const originalRemoveAsync = collection.removeAsync.bind(collection);
+    // eslint-disable-next-line prefer-object-spread
+    return Object.assign({}, collection, {
+      find(selector, options) {
+        return originalFind(
+          {
+            ...toSelector(selector),
+            ...filterOptions(options),
           },
-        },
-        { multi: true }
-      );
-    },
-  });
-};
+          options
+        );
+      },
+      async findOneAsync(selector, options) {
+        return originalFindOneAsync(
+          {
+            ...toSelector(selector),
+            ...filterOptions(options),
+          },
+          options
+        );
+      },
+      async removeAsync(
+        selector,
+        { shouldFetchFullDoc, hardRemove, ...options } = {}
+      ) {
+        const docsToRemove =
+          shouldFetchFullDoc &&
+          (await originalFind(toSelector(selector)).fetchAsync());
+
+        if (hardRemove) {
+          await originalRemoveAsync(selector);
+          return afterRemove({ doc: docsToRemove, collection, isRemove: true });
+        }
+
+        await originalUpdateAsync(
+          {
+            ...toSelector(selector),
+          },
+          {
+            $set: {
+              ...(options.$set || {}),
+              isRemoved: true,
+              removedAt: new Date(),
+            },
+          },
+          { multi: true }
+        );
+
+        return afterRemove({ doc: docsToRemove, collection, isRemove: true });
+      },
+    });
+  };

--- a/collections/package.js
+++ b/collections/package.js
@@ -1,7 +1,7 @@
 /* global Package */
 Package.describe({
   name: 'quave:collections',
-  version: '3.0.4',
+  version: '3.1.0',
   summary: 'Utility package to create Meteor collections with enhanced functionality',
   git: 'https://github.com/quavedev/meteor-packages/tree/main/collections',
 });

--- a/collections/package.js
+++ b/collections/package.js
@@ -1,7 +1,7 @@
 /* global Package */
 Package.describe({
   name: 'quave:collections',
-  version: '3.1.0',
+  version: '3.1.1',
   summary: 'Utility package to create Meteor collections with enhanced functionality',
   git: 'https://github.com/quavedev/meteor-packages/tree/main/collections',
 });


### PR DESCRIPTION
- Updated README.md to include new features for the `persistable` composer, allowing customization with `afterInsert` and `afterUpdate` functions, and introduced the `shouldFetchFullDoc` flag for fetching the old document.

- Modified `persistable.js` to implement the new `afterInsert` and `afterUpdate` hooks, enhancing document handling during save operations.

- Enhanced `softRemoval.js` to support an `afterRemove` function, enabling actions post-document removal, and added the `shouldFetchFullDoc` option for retrieving documents before removal.

These changes improve the flexibility and functionality of document persistence and removal in the collections.