### PR TITLE
Add noProcessExit config option for synced-cron

### DIFF
--- a/synced-cron/CHANGELOG.md
+++ b/synced-cron/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 
+## 2.3.1
+
+- Add `noProcessExit` config option (default: `false`). When set to `true`, SyncedCron will not call `process.exit()` after handling signals or fatal errors, allowing Meteor or other handlers to control the process lifecycle. Fixes [#15](https://github.com/quavedev/meteor-packages/issues/15).
+- Fix exit codes: use proper exit codes instead of always exiting with 0 — `SIGINT` exits with 130, `SIGTERM` with 143, and fatal errors with 1.
+
 ## 2.3.0 (2025-01-16)
 
 - Add automatic cleanup of blocked jobs from crashed processes on startup. This handles the case where a server crashes without gracefully terminating, leaving jobs without `finishedAt` in the collection.

--- a/synced-cron/README.md
+++ b/synced-cron/README.md
@@ -124,7 +124,16 @@ You can configure SyncedCron with the `config` method. Defaults are:
       than blockedJobTimeoutMs will be marked as terminated on startup.
       Default: true
     */
-    cleanupBlockedJobsOnStartup: true
+    cleanupBlockedJobsOnStartup: true,
+
+    /*
+      If true, SyncedCron will NOT call process.exit() after handling
+      signals (SIGTERM, SIGINT) or fatal errors (uncaughtException,
+      unhandledRejection). Set this to true if you want Meteor or
+      another handler to control the process lifecycle.
+      Default: false
+    */
+    noProcessExit: false
   });
 ```
 
@@ -134,7 +143,7 @@ SyncedCron automatically handles "blocked" jobs - jobs that never received a `fi
 
 **Automatic cleanup on startup**: When `cleanupBlockedJobsOnStartup` is enabled (default), SyncedCron will automatically mark blocked jobs from OTHER crashed processes as terminated when the server starts. Jobs from the current process are never affected.
 
-**Graceful shutdown**: SyncedCron automatically handles `SIGTERM`, `SIGINT`, `uncaughtException`, and `unhandledRejection` signals to mark running jobs from the current process as terminated before shutdown.
+**Graceful shutdown**: SyncedCron automatically handles `SIGTERM`, `SIGINT`, `uncaughtException`, and `unhandledRejection` signals to mark running jobs from the current process as terminated before shutdown. By default, SyncedCron will also call `process.exit()` after cleanup. Set `noProcessExit: true` to disable this behavior and let Meteor (or other handlers) control the process lifecycle.
 
 The cleanup adds a `terminatedBy` field to identify how the job was terminated:
 - `SIGTERM` / `SIGINT`: Graceful shutdown signal

--- a/synced-cron/package.js
+++ b/synced-cron/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   summary:
     'Allows you to define and run scheduled jobs across multiple servers.',
-  version: '2.3.0',
+  version: '2.3.1',
   name: 'quave:synced-cron',
   git: 'https://github.com/quavedev/meteor-synced-cron.git',
 });

--- a/synced-cron/synced-cron-server.js
+++ b/synced-cron/synced-cron-server.js
@@ -27,6 +27,11 @@ SyncedCron = {
 
     // Whether to cleanup blocked jobs from other crashed processes on startup
     cleanupBlockedJobsOnStartup: true,
+
+    // If true, SyncedCron will not call process.exit() after handling signals
+    // or fatal errors. Set this to true if you want Meteor (or another handler)
+    // to control the process lifecycle.
+    noProcessExit: false,
   },
   config: function (opts) {
     this.options = Object.assign({}, this.options, opts);
@@ -150,7 +155,9 @@ Meteor.startup(async function syncedCronStartup() {
       SyncedCron.pause();
 
       await cleanupRunningJobs(signal)
-      process.exit(0);
+      if (!options.noProcessExit) {
+        process.exit(signal === 'SIGINT' ? 130 : 143);
+      }
     }));
   });
 
@@ -161,7 +168,9 @@ Meteor.startup(async function syncedCronStartup() {
     // Only cleanup if there are no other error handlers
     if (process.listenerCount('uncaughtException') === 1) {
       await cleanupRunningJobs('UNCAUGHT_EXCEPTION');
-      process.exit(0);
+      if (!options.noProcessExit) {
+        process.exit(1);
+      }
     }
   });
 
@@ -171,7 +180,9 @@ Meteor.startup(async function syncedCronStartup() {
     // Only cleanup if there are no other error handlers
     if (process.listenerCount('unhandledRejection') === 1) {
       await cleanupRunningJobs('UNHANDLED_REJECTION');
-      process.exit(0);
+      if (!options.noProcessExit) {
+        process.exit(1);
+      }
     }
   });
 

--- a/synced-cron/synced-cron-server.js
+++ b/synced-cron/synced-cron-server.js
@@ -155,7 +155,7 @@ Meteor.startup(async function syncedCronStartup() {
       SyncedCron.pause();
 
       await cleanupRunningJobs(signal)
-      if (!options.noProcessExit) {
+      if (!SyncedCron.options.noProcessExit) {
         process.exit(signal === 'SIGINT' ? 130 : 143);
       }
     }));
@@ -168,7 +168,7 @@ Meteor.startup(async function syncedCronStartup() {
     // Only cleanup if there are no other error handlers
     if (process.listenerCount('uncaughtException') === 1) {
       await cleanupRunningJobs('UNCAUGHT_EXCEPTION');
-      if (!options.noProcessExit) {
+      if (!SyncedCron.options.noProcessExit) {
         process.exit(1);
       }
     }
@@ -180,7 +180,7 @@ Meteor.startup(async function syncedCronStartup() {
     // Only cleanup if there are no other error handlers
     if (process.listenerCount('unhandledRejection') === 1) {
       await cleanupRunningJobs('UNHANDLED_REJECTION');
-      if (!options.noProcessExit) {
+      if (!SyncedCron.options.noProcessExit) {
         process.exit(1);
       }
     }

--- a/synced-cron/synced-cron-tests.js
+++ b/synced-cron/synced-cron-tests.js
@@ -772,6 +772,57 @@ Tinytest.addAsync(
 );
 
 Tinytest.addAsync(
+  'Process exit is NOT called when noProcessExit is true',
+  async (test) => {
+    let exitCalled = false;
+    mockProcessExit();
+
+    // Override the mock to track if it was called
+    process.exit = () => {
+      exitCalled = true;
+    };
+
+    // Enable noProcessExit
+    const originalNoProcessExit = SyncedCron.options.noProcessExit;
+    SyncedCron.options.noProcessExit = true;
+
+    await SyncedCron._reset();
+
+    const testEntry = {
+      name: 'No Exit Job',
+      schedule(parser) {
+        return parser.text('every 1 second');
+      },
+      async job() {
+        await new Promise(resolve => setTimeout(resolve, 1000));
+        return 'completed';
+      },
+    };
+
+    SyncedCron.add(testEntry);
+    const entry = SyncedCron._entries[testEntry.name];
+
+    // Start the job
+    SyncedCron._entryWrapper(entry)(new Date());
+
+    // Wait a bit to ensure the job has started
+    await new Promise(resolve => setTimeout(resolve, 100));
+
+    // Simulate fatal error (with no other handlers)
+    process.emit('uncaughtException', new Error('Fatal error'));
+
+    // Wait for cleanup to complete
+    await new Promise(resolve => setTimeout(resolve, 100));
+
+    test.isFalse(exitCalled, 'Process.exit should NOT have been called when noProcessExit is true');
+
+    // Restore
+    SyncedCron.options.noProcessExit = originalNoProcessExit;
+    restoreProcessExit();
+  }
+);
+
+Tinytest.addAsync(
   '_cleanupBlockedJobs cleans up jobs from other processes on startup',
   async (test) => {
     await SyncedCron._reset();


### PR DESCRIPTION
## Summary

- Adds a `noProcessExit` config option (default: `false`) that prevents SyncedCron from calling `process.exit()` after handling signals or fatal errors, letting Meteor or other handlers control the process lifecycle
- Fixes exit codes: `SIGINT` → 130, `SIGTERM` → 143, fatal errors → 1 (instead of always exiting with 0)
- Adds test for `noProcessExit` behavior, bumps version to 2.3.1

Fixes #15

## Usage

```js
SyncedCron.config({
  noProcessExit: true, // SyncedCron will clean up jobs but won't call process.exit()
});
```

## Test plan

- [ ] Existing test "Process exit is called on fatal errors" still passes (default behavior unchanged)
- [ ] New test "Process exit is NOT called when noProcessExit is true" verifies the option works
- [ ] Run `meteor test-packages ./synced-cron` to verify all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)