### PR TITLE
Preserve synced-cron userId in nested method calls

### DIFF
--- a/synced-cron/package.js
+++ b/synced-cron/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   summary:
     'Allows you to define and run scheduled jobs across multiple servers.',
-  version: '2.4.0',
+  version: '2.4.1',
   name: 'quave:synced-cron',
   git: 'https://github.com/quavedev/meteor-synced-cron.git',
 });
@@ -13,7 +13,7 @@ Package.onUse(function (api) {
 
   api.use('ecmascript');
 
-  api.use(['check', 'mongo', 'logging', 'random'], 'server');
+  api.use(['check', 'ddp', 'ddp-common', 'mongo', 'logging', 'random'], 'server');
 
   api.addFiles(['synced-cron-server.js'], 'server');
 
@@ -21,7 +21,7 @@ Package.onUse(function (api) {
 });
 
 Package.onTest(function (api) {
-  api.use(['check', 'mongo', 'random'], 'server');
+  api.use(['check', 'ddp', 'ddp-common', 'mongo', 'random'], 'server');
   api.use(['tinytest', 'logging']);
 
   api.addFiles(['synced-cron-server.js', 'synced-cron-tests.js'], ['server']);

--- a/synced-cron/synced-cron-server.js
+++ b/synced-cron/synced-cron-server.js
@@ -84,6 +84,23 @@ const partial =
   (...remainingArgs) =>
     func(...boundArgs, ...remainingArgs);
 
+function createCronMethodInvocation(entry) {
+  let invocation;
+
+  invocation = new DDPCommon.MethodInvocation({
+    isSimulation: false,
+    userId: entry.userId ?? null,
+    setUserId(userId) {
+      entry.userId = userId;
+      invocation.userId = userId;
+    },
+    connection: entry.connection ?? null,
+    randomSeed: entry.randomSeed ?? null,
+  });
+
+  return invocation;
+}
+
 Meteor.startup(async function syncedCronStartup() {
   const options = SyncedCron.options;
 
@@ -367,7 +384,11 @@ SyncedCron._entryWrapper = function (entry) {
     // run and record the job
     try {
       log.info(`Starting "${entry.name}".`);
-      const output = await entry.job(intendedAt, entry.name); // <- Run the actual job
+      const invocation = createCronMethodInvocation(entry);
+      const output = await DDP._CurrentMethodInvocation.withValue(
+        invocation,
+        () => entry.job.call(entry, intendedAt, entry.name)
+      );
 
       log.info(`Finished "${entry.name}".`);
       if (entry.persist) {

--- a/synced-cron/synced-cron-tests.js
+++ b/synced-cron/synced-cron-tests.js
@@ -71,6 +71,40 @@ Tinytest.addAsync('Exceptions work', async function (test) {
 });
 
 Tinytest.addAsync(
+  'Cron jobs preserve userId in nested Meteor.callAsync calls',
+  async function (test) {
+    await SyncedCron._reset();
+
+    const methodName = `syncedCronGetUserId_${Random.id()}`;
+    const expectedUserId = Random.id();
+    let nestedMethodUserId;
+
+    Meteor.methods({
+      [methodName]: function () {
+        return this.userId;
+      },
+    });
+
+    SyncedCron.add({
+      name: `User Context Job ${Random.id()}`,
+      userId: expectedUserId,
+      schedule: TestEntry.schedule,
+      job: async function () {
+        nestedMethodUserId = await Meteor.callAsync(methodName);
+
+        return nestedMethodUserId;
+      },
+    });
+
+    const entry = Object.values(SyncedCron._entries)[0];
+
+    await SyncedCron._entryWrapper(entry)(new Date());
+
+    test.equal(nestedMethodUserId, expectedUserId);
+  }
+);
+
+Tinytest.addAsync(
   'SyncedCron.nextScheduledAtDate works',
   async function (test) {
     await SyncedCron._reset();


### PR DESCRIPTION
## Summary

- preserve cron job `userId` across nested server-side Meteor method calls
- add a regression test that fails when `Meteor.callAsync` loses the cron entry context
- declare the explicit DDP package dependencies used by the fix

## Root Cause

Synced cron jobs were executed directly through `entry.job(...)`, so nested server-side Meteor method calls ran without a current DDP method invocation. That caused `this.userId` to fall back to `null` inside the nested method.

## Validation

- `TEST_BROWSER_DRIVER=puppeteer meteor test-packages ./ --once --driver-package test-in-console --port 3201`
