### PR TITLE
Replace deprecated Buffer constructors in meteor-slingshot

### DIFF
--- a/meteor-slingshot/CHANGELOG.md
+++ b/meteor-slingshot/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Slingshot Changelog
 
+## Version 2.0.4
+
+### Enhancements
+
+- Replace deprecated Buffer() / new Buffer()
+
 ## Version 0.7.1
 
 ### Enhancements

--- a/meteor-slingshot/lib/storage-policy.js
+++ b/meteor-slingshot/lib/storage-policy.js
@@ -96,7 +96,7 @@ Slingshot.StoragePolicy = function () {
 
     stringify: function (encoding) {
       /* global Buffer: false */
-      return Buffer(JSON.stringify(policy), 'utf-8').toString(
+      return Buffer.from(JSON.stringify(policy), 'utf-8').toString(
         encoding || 'base64'
       );
     },

--- a/meteor-slingshot/package.js
+++ b/meteor-slingshot/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   name: 'quave:slingshot',
   summary: 'Directly post files to cloud storage services, such as AWS-S3.',
-  version: '2.0.3',
+  version: '2.0.4',
   git: 'https://github.com/quavedev/meteor-packages',
 });
 

--- a/meteor-slingshot/services/aws-s3.js
+++ b/meteor-slingshot/services/aws-s3.js
@@ -273,6 +273,6 @@ function hmac256(key, data, encoding) {
   /* global Buffer: false */
   return crypto
     .createHmac('sha256', key)
-    .update(new Buffer(data, 'utf-8'))
+    .update(Buffer.from(data, 'utf-8'))
     .digest(encoding);
 }

--- a/meteor-slingshot/services/rackspace.js
+++ b/meteor-slingshot/services/rackspace.js
@@ -111,7 +111,7 @@ Slingshot.RackspaceFiles = {
 
     return Npm.require('crypto')
       .createHmac('sha1', secretkey)
-      .update(new Buffer(policy, 'utf-8'))
+      .update(Buffer.from(policy, 'utf-8'))
       .digest('hex');
   },
 };


### PR DESCRIPTION
## Summary
- replace deprecated `Buffer()` / `new Buffer()` usage in `meteor-slingshot`
- keep the change limited to warning removal with no behavioral changes

## Root Cause
Node now warns on the deprecated Buffer constructor forms. `meteor-slingshot` still had three server-side call sites using those legacy constructors in policy encoding and HMAC input preparation.

## Changes
- `meteor-slingshot/lib/storage-policy.js`: `Buffer(...)` -> `Buffer.from(...)`
- `meteor-slingshot/services/aws-s3.js`: `new Buffer(...)` -> `Buffer.from(...)`
- `meteor-slingshot/services/rackspace.js`: `new Buffer(...)` -> `Buffer.from(...)`

## Validation
- searched `meteor-slingshot` for remaining `Buffer(` / `new Buffer(` occurrences after the patch
- reviewed the diff to confirm the change is limited to constructor replacement only

## Impact
This removes the deprecation warning on modern Node runtimes without changing the encoded payloads or signatures produced by the package.
